### PR TITLE
Add client reference ID to Stripe checkout sessions

### DIFF
--- a/supabase/functions/create-checkout/index.ts
+++ b/supabase/functions/create-checkout/index.ts
@@ -97,6 +97,7 @@ serve(async (req) => {
       mode: "subscription",
       success_url: success_url || `${req.headers.get("origin")}/dashboard`,
       cancel_url: cancel_url || `${req.headers.get("origin")}/`,
+      client_reference_id: user.id,
       metadata: {
         user_id: user.id,
         lookup_key: lookup_key


### PR DESCRIPTION
## Summary
- include the authenticated user's ID as the client reference ID when creating Stripe checkout sessions so webhooks can associate events with the user

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e63cc4e0832c86662cde679ce801